### PR TITLE
feat(vectorizer): support siliconflow free API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /dist
 .vscode/
 __pycache__/
+examples/

--- a/kag/common/vectorizer/__init__.py
+++ b/kag/common/vectorizer/__init__.py
@@ -13,6 +13,8 @@
 from kag.common.vectorizer.local_bge_m3_vectorizer import LocalBGEM3Vectorizer
 from kag.common.vectorizer.local_bge_vectorizer import LocalBGEVectorizer
 from kag.common.vectorizer.openai_vectorizer import OpenAIVectorizer
+from kag.common.vectorizer.siliconflow_vectorizer import SiliconFlowVectorizer
+
 from kag.common.vectorizer.vectorizer import Vectorizer
 from kag.common.vectorizer.vectorizer_config_checker import VectorizerConfigChecker
 
@@ -21,6 +23,7 @@ __all__ = [
     "LocalBGEM3Vectorizer",
     "LocalBGEVectorizer",
     "OpenAIVectorizer",
+    "SiliconFlowVectorizer",
     "Vectorizer",
     "VectorizerConfigChecker",
 ]

--- a/kag/common/vectorizer/siliconflow_vectorizer.py
+++ b/kag/common/vectorizer/siliconflow_vectorizer.py
@@ -1,0 +1,94 @@
+# Copyright 2023 OpenSPG Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied.
+
+from typing import Any, Union, Iterable, Dict
+from openai import OpenAI
+from kag.common.vectorizer.vectorizer import Vectorizer
+import requests
+
+EmbeddingVector = Iterable[float]
+
+
+class SiliconFlowVectorizer(Vectorizer):
+    """
+    Invoke SiliconFlow API services to turn texts into embedding vectors.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.model = config.get("model","netease-youdao/bce-embedding-base_v1")
+        self.api_key = config.get("api_key")
+        self.base_url = config.get("base_url")
+        if not self.api_key:
+            raise ValueError("SiliconFlow API key is not set")
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    @classmethod
+    def _from_config(cls, config: Dict[str, Any]) -> Vectorizer:
+        """
+        Create vectorizer from `config`.
+
+        :param config: vectorizer config
+        :type config: Dict[str, Any]
+        :return: vectorizer instance
+        :rtype: Vectorizer
+        """
+        vectorizer = cls(config)
+        return vectorizer
+    
+    def base64_to_float_array(self, base64_string):
+        # 解码base64字符串
+        decoded_bytes = base64.b64decode(base64_string)
+        
+        # 将字节转换为浮点数，这里假设每个浮点数是4字节（即float类型）
+        # '<' 表示小端格式，'f' 表示单精度浮点数
+        float_array = []
+        for i in range(0, len(decoded_bytes), 4):
+            # 提取4个字节
+            bytes_chunk = decoded_bytes[i:i+4]
+            # 解码为浮点数
+            float_num = struct.unpack('<f', bytes_chunk)[0]
+            float_array.append(float_num)
+        
+        return float_array
+
+    def vectorize(self, texts: Union[str, Iterable[str]]) -> Union[EmbeddingVector, Iterable[EmbeddingVector]]:
+        """
+        Vectorize a text string into an embedding vector or multiple text strings into
+        multiple embedding vectors.
+
+        :param texts: texts to vectorize
+        :type texts: str or Iterable[str]
+        :return: embedding vectors of the texts
+        :rtype: EmbeddingVector or Iterable[EmbeddingVector]
+        """
+        if text is None:
+            raise ValueError('This api only support text')
+        
+        url = "https://api.siliconflow.cn/v1/embeddings"
+
+        payload = {
+            "model": self.model,
+            "input": text,
+            "encoding_format": "base64"
+        }
+        headers = {
+            "accept": "application/json",
+            "content-type": "application/json",
+            "authorization": self.api_key
+        }
+
+        response = requests.post(url, json=payload, headers=headers)
+        import pdb
+        pdb.set_trace()
+        json_obj = json.loads(response.text)
+        emb_encoded = json_obj['data'][0]['embedding']
+        return base64_to_float_array(base64_string=emb_encoded)

--- a/kag/common/vectorizer/siliconflow_vectorizer.py
+++ b/kag/common/vectorizer/siliconflow_vectorizer.py
@@ -94,7 +94,3 @@ class SiliconFlowVectorizer(Vectorizer):
             embeddings.append(emb_arr)
         
         return embeddings
-
-if __name__ == '__main__':
-    inst = SiliconFlowVectorizer(config={"api_key": "sk-ducerqngypudxuevovkmvsbatstjyikvbjdpylfsvkfqcgox", "base_url": "https://api.siliconflow.cn/v1"})
-    print(inst.vectorize(texts='hello'))

--- a/kag/examples/.gitignore
+++ b/kag/examples/.gitignore
@@ -1,1 +1,0 @@
-KagDemo/

--- a/kag/examples/.gitignore
+++ b/kag/examples/.gitignore
@@ -1,0 +1,1 @@
+KagDemo/


### PR DESCRIPTION
## Intention

`chatgpt` and `ollama serve` is too expensive.

Let's support siliconcloud **free** API, see https://cloud.siliconflow.cn/models

## Test

Here is my config,  test passed.

```toml
[project]
namespace = KagDemoSiliconFix1
host_addr = http://10.1.96.66:8887

[vectorizer]
vectorizer = kag.common.vectorizer.SiliconFlowVectorizer
model = netease-youdao/bce-embedding-base_v1
api_key = sk-[you_own_api_key]
base_url = https://api.siliconflow.cn/v1
vector_dimensions = 768

[llm]
client_type = maas
base_url = https://api.siliconflow.cn
model = Qwen/Qwen2.5-7B-Instruct
api_key = sk-[you_own_api_key]

[log]
level = INFO

[prompt]
language = en
biz_scene = default
```
