### PR TITLE
fix(solver): 修改了slover中sum和verify功能求解器的传入参数

### DIFF
--- a/kag/solver/logic/core_modules/parser/logic_node_parser.py
+++ b/kag/solver/logic/core_modules/parser/logic_node_parser.py
@@ -536,11 +536,11 @@ class ParseLogicForm:
         elif low_operator in ["deduce"]:
             node: DeduceNode = DeduceNode.parse_node(args_str)
         elif low_operator in ["verify"]:
-            node: VerifyNode = VerifyNode.parse_node(args_str)
+            node: VerifyNode = VerifyNode.parse_node(input_str)
         elif low_operator in ["count"]:
             node: CountNode = CountNode.parse_node(args_str, output_name)
         elif low_operator in ["sum"]:
-            node: SumNode = SumNode.parse_node(args_str)
+            node: SumNode = SumNode.parse_node(input_str)
         elif low_operator in ["sort"]:
             node: SortNode = SortNode.parse_node(args_str)
         elif low_operator in ["compare"]:

--- a/kag/solver/logic/core_modules/parser/logic_node_parser.py
+++ b/kag/solver/logic/core_modules/parser/logic_node_parser.py
@@ -174,7 +174,7 @@ class SumNode(LogicNode):
     @staticmethod
     def parse_node(input_str):
         # count_alias=count(alias)
-        match = re.match(r'(\w+)[\(\（](.*)[\)\）](->)?(.*)?', input_str)
+        match = re.match(r'(\w+)[\(\（](.*)[\)\）](->)?(.*)?', input_str.strip())
         if not match:
             raise RuntimeError(f"parse logic form error {input_str}")
         # print('match:',match.groups())


### PR DESCRIPTION
我按照 OpenSPG 的 用户手册v0.5 中的黑产挖掘项目的操作生成了知识库，随后我进行了提问：张*三比裘**风险高多少？
我的 sub_query 和 logic_forms 如下：
![image](https://github.com/user-attachments/assets/f2cc1272-0b53-41e8-99a5-bcf2c40b4e80)
而在对这个逻辑符号进行求解的过程中，首先对 operator 和 args_str 进行了解析。如果在进行第三步sum计算的时候，则在逻辑中还要再进行抽取一次。但此时传给 SumNode.parse_node 的只有 o1, -o2，所以会发生匹配不到而报错。
![image](https://github.com/user-attachments/assets/6ae955bc-fba4-41e7-bbeb-a83100cd3762)
![image](https://github.com/user-attachments/assets/f7be6970-5041-4a08-ba91-1af6c15065d2)
我理解原本的逻辑应该这里匹配的是整个的 sum(o1, o2) -> diff 逻辑表达式。同理 verify 也是一样。所以我将这两个方法的传入参数改成了匹配前的 input_str 。