### PR TITLE
fix(utils): 'ModuleNotFoundError: No module named xxx' error in Windows

### DIFF
--- a/kag/common/registry/utils.py
+++ b/kag/common/registry/utils.py
@@ -36,7 +36,7 @@ def import_modules_from_path(path: str) -> None:
     """
     path = os.path.abspath(os.path.normpath(path))
     importlib.invalidate_caches()
-    tmp = path.rsplit("/", 1)
+    tmp = path.rsplit(os.sep, 1)
     if len(tmp) == 1:
         module_path = "."
         package_name = tmp[0]


### PR DESCRIPTION
fix "ModuleNotFoundError: No module named 'xxx'" error in Windows os

![image](https://github.com/user-attachments/assets/d448f7b0-793e-4423-83a0-87b275422aa7)
