### PR TITLE
fix(builder): removed model parameter from azure openai

### DIFF
--- a/kag/common/llm/openai_client.py
+++ b/kag/common/llm/openai_client.py
@@ -163,7 +163,6 @@ class AzureOpenAIClient(LLMClient):
             api_key=self.api_key,
             base_url=self.base_url,
             azure_deployment=self.azure_deployment,
-            model=self.model,
             api_version=self.api_version,
             azure_ad_token=self.azure_ad_token,
             azure_ad_token_provider=self.azure_ad_token_provider,

--- a/kag/common/vectorize_model/openai_model.py
+++ b/kag/common/vectorize_model/openai_model.py
@@ -107,7 +107,6 @@ class AzureOpenAIVectorizeModel(VectorizeModelABC):
             api_key=api_key,
             base_url=base_url,
             azure_deployment=azure_deployment,
-            model=model,
             api_version=api_version,
             azure_ad_token=azure_ad_token,
             azure_ad_token_provider=azure_ad_token_provider,


### PR DESCRIPTION
Azure OpenAI have not a model parameter. You write the model in the base url.