### PR TITLE
fix(solver): Some LLM will return answer with leading newline

### DIFF
--- a/kag/solver/prompt/default/resp_judge.py
+++ b/kag/solver/prompt/default/resp_judge.py
@@ -44,7 +44,7 @@ class RespJudge(PromptABC):
         return if_finished
 
     def parse_response_zh(self, satisfied_info: str):
-        if satisfied_info.startswith("是"):
+        if satisfied_info.strip().startswith("是"):
             if_finished = True
         else:
             if_finished = False


### PR DESCRIPTION
deepseek-r1 will return answer with leading newline, causing the answered question being refined unnecessarily.