### PR TITLE
Multiple fixes to the KAG core code improve stability

### DIFF
--- a/kag/builder/component/mapping/spg_type_mapping.py
+++ b/kag/builder/component/mapping/spg_type_mapping.py
@@ -12,6 +12,7 @@
 from collections import defaultdict
 from typing import Dict, List, Callable
 
+import math
 import pandas
 
 from knext.schema.client import BASIC_TYPES
@@ -126,6 +127,10 @@ class SPGTypeMapping(MappingABC):
                 prop = self.spg_type.properties.get(prop_name)
                 o_label = prop.object_type_name_en
                 if o_label not in BASIC_TYPES:
+                    # If property key exists but value is empty (NaN), skip
+                    if not prop_value or (type(prop_value) is float and math.isnan(prop_value)):
+                        continue
+
                     prop_value_list = prop_value.split(",")
                     for o_id in prop_value_list:
                         if prop_name in self.link_funcs:

--- a/kag/builder/prompt/default/ner.py
+++ b/kag/builder/prompt/default/ner.py
@@ -165,8 +165,15 @@ class OpenIENERPrompt(PromptABC):
             rsp = json.loads(rsp)
         if isinstance(rsp, dict) and "output" in rsp:
             rsp = rsp["output"]
-        if isinstance(rsp, dict) and "named_entities" in rsp:
-            entities = rsp["named_entities"]
+        # - case1: {'named_entities': [...]}
+        # - case2: {'entities': [...]}
+        if isinstance(rsp, dict):
+            if "named_entities" in rsp:
+                entities = rsp["named_entities"]
+            elif "entities" in rsp:
+                entities = rsp["entities"]
+            else:
+                entities = rsp
         else:
             entities = rsp
 

--- a/kag/common/vectorize_model/openai_model.py
+++ b/kag/common/vectorize_model/openai_model.py
@@ -56,11 +56,18 @@ class OpenAIVectorizeModel(VectorizeModelABC):
         Returns:
             Union[EmbeddingVector, Iterable[EmbeddingVector]]: The embedding vector(s) of the text(s).
         """
+        # Some models require a list of strings as input rather than a single string, otherwise the model will generate
+        # vector for each character in the input string. Convert single string to list of strings to unify the input format.
+        if isinstance(texts, str):
+            texts = [texts]
+
         results = self.client.embeddings.create(
             input=texts, model=self.model, timeout=self.timeout
         )
         results = [item.embedding for item in results.data]
-        if isinstance(texts, str):
+
+        # If the input is a single string or a list with only one element, return the first element of the results list.
+        if isinstance(texts, str) or len(texts) == 1:
             assert len(results) == 1
             return results[0]
         else:
@@ -125,11 +132,18 @@ class AzureOpenAIVectorizeModel(VectorizeModelABC):
         Returns:
             Union[EmbeddingVector, Iterable[EmbeddingVector]]: The embedding vector(s) of the text(s).
         """
+        # Some models require a list of strings as input rather than a single string, otherwise the model will generate
+        # vector for each character in the input string. Convert single string to list of strings to unify the input format.
+        if isinstance(texts, str):
+            texts = [texts]
+
         results = self.client.embeddings.create(
             input=texts, model=self.model, timeout=self.timeout
         )
         results = [item.embedding for item in results.data]
-        if isinstance(texts, str):
+
+        # If the input is a single string or a list with only one element, return the first element of the results list.
+        if isinstance(texts, str) or len(texts) == 1:
             assert len(results) == 1
             return results[0]
         else:

--- a/kag/solver/execute/default_lf_executor.py
+++ b/kag/solver/execute/default_lf_executor.py
@@ -152,7 +152,8 @@ class DefaultLFExecutor(LFExecutorABC):
             all_related_entities = list(set(all_related_entities))
             sub_query = self._generate_sub_query_with_history_qa(history, lf.query)
             doc_retrieved = self.chunk_retriever.recall_docs(
-                queries=[query, sub_query],
+                # sub_query could be the same as original query
+                queries=[query, sub_query] if sub_query != query else [query],
                 retrieved_spo=all_related_entities,
                 kwargs=self.params,
             )

--- a/kag/solver/logic/core_modules/common/text_sim_by_vector.py
+++ b/kag/solver/logic/core_modules/common/text_sim_by_vector.py
@@ -55,6 +55,12 @@ class TextSimilarity:
                     need_call_emb_text.append(text)
             if len(need_call_emb_text) > 0:
                 emb_res = self.vectorize_model.vectorize(need_call_emb_text)
+
+                # If need_call_emb_text has only one element and emb_res is not of type list[list], convert emb_res to a list of lists
+                if len(need_call_emb_text) == 1:
+                    if emb_res and type(emb_res[0]) != list:
+                        emb_res = [emb_res]
+
                 for text, text_emb in zip(need_call_emb_text, emb_res):
                     tmp_map[text] = text_emb
                     if is_cached:

--- a/kag/solver/prompt/default/question_ner.py
+++ b/kag/solver/prompt/default/question_ner.py
@@ -65,8 +65,15 @@ class QuestionNER(PromptABC):
             rsp = json.loads(rsp)
         if isinstance(rsp, dict) and "output" in rsp:
             rsp = rsp["output"]
-        if isinstance(rsp, dict) and "named_entities" in rsp:
-            entities = rsp["named_entities"]
+        # - case1: {'named_entities': [...]}
+        # - case2: {'entities': [...]}
+        if isinstance(rsp, dict):
+            if "named_entities" in rsp:
+                entities = rsp["named_entities"]
+            elif "entities" in rsp:
+                entities = rsp["entities"]
+            else:
+                entities = rsp
         else:
             entities = rsp
 


### PR DESCRIPTION
Major changes:
- Multiple fixes to LLM response parsers to improve general stability, those are confirmed corner cased during my tests
- A small change to `openai_model.py`'s VectorizeModel, to unify input format as vector models will behave differently on a single single input 
- A change to registrable.py's `remove_optional` method, to support both `Optional` typing and py310's pipe typing syntax such as `int | None` during instance injection

Please see code comments for more details, thanks!