### PR TITLE
fix(example): fix the prompt of ner,std,triple

### DIFF
--- a/kag/examples/medicine/builder/prompt/ner.py
+++ b/kag/examples/medicine/builder/prompt/ner.py
@@ -30,14 +30,14 @@ class OpenIENERPrompt(PromptABC):
             {
                 "input": "烦躁不安、语妄、失眠酌用镇静药，禁用抑制呼吸的镇静药。\n3.并发症的处理经抗菌药物治疗后，高热常在24小时内消退，或数日内逐渐下降。\n若体温降而复升或3天后仍不降者，应考虑SP的肺外感染。\n治疗：接胸腔压力调节管＋吸引机负压吸引水瓶装置闭式负压吸引宜连续，如经12小时后肺仍未复张，应查找原因。",
                 "output": [
-                        {"entity": "烦躁不安", "category": "Symptom"},
-                        {"entity": "语妄", "category": "Symptom"},
-                        {"entity": "失眠", "category": "Symptom"},
-                        {"entity": "镇静药", "category": "Medicine"},
-                        {"entity": "肺外感染", "category": "Disease"},
-                        {"entity": "胸腔压力调节管", "category": "MedicalEquipment"},
-                        {"entity": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
-                        {"entity": "闭式负压吸引", "category": "SurgicalOperation"}
+                        {"name": "烦躁不安", "category": "Symptom"},
+                        {"name": "语妄", "category": "Symptom"},
+                        {"name": "失眠", "category": "Symptom"},
+                        {"name": "镇静药", "category": "Medicine"},
+                        {"name": "肺外感染", "category": "Disease"},
+                        {"name": "胸腔压力调节管", "category": "MedicalEquipment"},
+                        {"name": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
+                        {"name": "闭式负压吸引", "category": "SurgicalOperation"}
                     ]
             }
         ],

--- a/kag/examples/medicine/builder/prompt/std.py
+++ b/kag/examples/medicine/builder/prompt/std.py
@@ -25,24 +25,24 @@ class OpenIEEntitystandardizationdPrompt(PromptABC):
     "example": {
         "input": "烦躁不安、语妄、失眠酌用镇静药，禁用抑制呼吸的镇静药。\n3.并发症的处理经抗菌药物治疗后，高热常在24小时内消退，或数日内逐渐下降。\n若体温降而复升或3天后仍不降者，应考虑SP的肺外感染，如腋胸、心包炎或关节炎等。治疗：接胸腔压力调节管＋吸引机负压吸引水瓶装置闭式负压吸引宜连续，如经12小时后肺仍未复张，应查找原因。",
         "named_entities": [
-            {"entity": "烦躁不安", "category": "Symptom"},
-            {"entity": "语妄", "category": "Symptom"},
-            {"entity": "失眠", "category": "Symptom"},
-            {"entity": "镇静药", "category": "Medicine"},
-            {"entity": "肺外感染", "category": "Disease"},
-            {"entity": "胸腔压力调节管", "category": "MedicalEquipment"},
-            {"entity": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
-            {"entity": "闭式负压吸引", "category": "SurgicalOperation"}
+            {"name": "烦躁不安", "category": "Symptom"},
+            {"name": "语妄", "category": "Symptom"},
+            {"name": "失眠", "category": "Symptom"},
+            {"name": "镇静药", "category": "Medicine"},
+            {"name": "肺外感染", "category": "Disease"},
+            {"name": "胸腔压力调节管", "category": "MedicalEquipment"},
+            {"name": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
+            {"name": "闭式负压吸引", "category": "SurgicalOperation"}
         ],
         "output": [
-            {"entity": "烦躁不安", "category": "Symptom", "official_name": "焦虑不安"},
-            {"entity": "语妄", "category": "Symptom", "official_name": "谵妄"},
-            {"entity": "失眠", "category": "Symptom", "official_name": "失眠症"},
-            {"entity": "镇静药", "category": "Medicine", "official_name": "镇静剂"},
-            {"entity": "肺外感染", "category": "Disease", "official_name": "肺外感染"},
-            {"entity": "胸腔压力调节管", "category": "MedicalEquipment", "official_name": "胸腔引流管"},
-            {"entity": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment", "official_name": "负压吸引装置"},
-            {"entity": "闭式负压吸引", "category": "SurgicalOperation", "official_name": "闭式负压引流"}
+            {"name": "烦躁不安", "category": "Symptom", "official_name": "焦虑不安"},
+            {"name": "语妄", "category": "Symptom", "official_name": "谵妄"},
+            {"name": "失眠", "category": "Symptom", "official_name": "失眠症"},
+            {"name": "镇静药", "category": "Medicine", "official_name": "镇静剂"},
+            {"name": "肺外感染", "category": "Disease", "official_name": "肺外感染"},
+            {"name": "胸腔压力调节管", "category": "MedicalEquipment", "official_name": "胸腔引流管"},
+            {"name": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment", "official_name": "负压吸引装置"},
+            {"name": "闭式负压吸引", "category": "SurgicalOperation", "official_name": "闭式负压引流"}
         ]
     },
     "input": $input,
@@ -71,10 +71,10 @@ class OpenIEEntitystandardizationdPrompt(PromptABC):
         entities = kwargs.get("named_entities", [])
         for entity in standardized_entity:
             merged.append(entity)
-            entities_with_offical_name.add(entity["entity"])
+            entities_with_offical_name.add(entity["name"])
         # in case llm ignores some entities
         for entity in entities:
-            if entity["entity"] not in entities_with_offical_name:
+            if entity["name"] not in entities_with_offical_name:
                 entity["official_name"] = entity["entity"]
                 merged.append(entity)
         return merged

--- a/kag/examples/medicine/builder/prompt/triple.py
+++ b/kag/examples/medicine/builder/prompt/triple.py
@@ -26,14 +26,14 @@ class OpenIETriplePrompt(PromptABC):
     "example": {
         "input": "烦躁不安、语妄、失眠酌用镇静药，禁用抑制呼吸的镇静药。\n3.并发症的处理经抗菌药物治疗后，高热常在24小时内消退，或数日内逐渐下降。\n若体温降而复升或3天后仍不降者，应考虑SP的肺外感染，如腋胸、心包炎或关节炎等。治疗：接胸腔压力调节管＋吸引机负压吸引水瓶装置闭式负压吸引宜连续，如经12小时后肺仍未复张，应查找原因。",
         "entity_list": [
-            {"entity": "烦躁不安", "category": "Symptom"},
-            {"entity": "语妄", "category": "Symptom"},
-            {"entity": "失眠", "category": "Symptom"},
-            {"entity": "镇静药", "category": "Medicine"},
-            {"entity": "肺外感染", "category": "Disease"},
-            {"entity": "胸腔压力调节管", "category": "MedicalEquipment"},
-            {"entity": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
-            {"entity": "闭式负压吸引", "category": "SurgicalOperation"}
+            {"name": "烦躁不安", "category": "Symptom"},
+            {"name": "语妄", "category": "Symptom"},
+            {"name": "失眠", "category": "Symptom"},
+            {"name": "镇静药", "category": "Medicine"},
+            {"name": "肺外感染", "category": "Disease"},
+            {"name": "胸腔压力调节管", "category": "MedicalEquipment"},
+            {"name": "吸引机负压吸引水瓶装置", "category": "MedicalEquipment"},
+            {"name": "闭式负压吸引", "category": "SurgicalOperation"}
         ],
         "output":[
             ["烦躁不安", "酌用", "镇静药"],


### PR DESCRIPTION
我修改了 examples/medicine/builder/prompt/ 目录下的 ner.py std.py triple.py 文件中的prompt提示词。
目前的提示词中，生成的结果均是entity，例如：{"entity": "烦躁不安", "category": "Symptom"}
但目前的`/kag/builder/component/extractor/schema_free_extractor.py`中的逻辑均是对实体的“name”进行提取和判断。例如`_named_entity_recognition_process`函数中最后的
![image](https://github.com/user-attachments/assets/e422d1e6-cae6-459b-bf34-4c0ffb405795)
再例如`assemble_sub_graph_with_spg_records`函数中的
![image](https://github.com/user-attachments/assets/59288790-0c7a-4186-901b-a032fb2e4a11)
包括后续的生图和标准化代码，均是对抽取出来实体的“name”进行抽取，所以我推理提示词中应该是`name`而不是`entity`。如果以目前的`entity`来运行代码的话，则llm抽取实体是可以，但后续处理得到的结果均为空，导致生图失败。