### PR TITLE
Enhance vectorizer config handling in project.py

### DIFF
--- a/knext/command/sub_command/project.py
+++ b/knext/command/sub_command/project.py
@@ -166,17 +166,24 @@ def create_project(
     llm_config_checker = LLMConfigChecker()
     vectorize_model_config_checker = VectorizeModelConfigChecker()
     llm_config = config.get("chat_llm", {})
-    vectorize_model_config = config.get("vectorizer", {}) or config.get(
-        "vectorize_model", {}
-    )
-    if "vectorizer" not in config and "vectorize_model" in config:
-        config["vectorizer"] = config["vectorize_model"]
+    vectorizer_config = config.get("vectorizer",{})
+    vectorize_model_config = config.get("vectorize_model", {})
+    if vectorizer_config:
+        vectorize_model_config = vectorizer_config
+    elif vectorize_model_config:
+        vectorizer_config = vectorize_model_config
+    else:
+        vectorizer_config = vectorize_model_config = {}
+
+    if vectorizer_config or vectorize_model_config:
+        config["vectorizer"] = vectorizer_config
+        config["vectorize_model"] = vectorize_model_config
     try:
         llm_config_checker.check(json.dumps(llm_config))
-        dim = vectorize_model_config_checker.check(json.dumps(vectorize_model_config))
-        if "vectorizer" in config and isinstance(config["vectorizer"], dict):
+        dim = vectorize_model_config_checker.check(json.dumps(vectorizer_config))
+        if isinstance(config.get("vectorizer"), dict):
             config["vectorizer"]["vector_dimensions"] = dim
-        if "vectorize_model" in config and isinstance(config["vectorize_model"], dict):
+        if isinstance(config.get("vectorize_model"), dict):
             config["vectorize_model"]["vector_dimensions"] = dim
     except Exception as e:
         click.secho(f"Error: {e}", fg="bright_red")

--- a/knext/command/sub_command/project.py
+++ b/knext/command/sub_command/project.py
@@ -170,7 +170,7 @@ def create_project(
         "vectorize_model", {}
     )
     if "vectorizer" not in config and "vectorize_model" in config:
-        config["vectorizer"] = config.get("vectorize_model", {})
+        config[“vectorizer”] = config[“vectorize_model”]
     try:
         llm_config_checker.check(json.dumps(llm_config))
         dim = vectorize_model_config_checker.check(json.dumps(vectorize_model_config))

--- a/knext/command/sub_command/project.py
+++ b/knext/command/sub_command/project.py
@@ -170,7 +170,7 @@ def create_project(
         "vectorize_model", {}
     )
     if "vectorizer" not in config and "vectorize_model" in config:
-        config[“vectorizer”] = config[“vectorize_model”]
+        config["vectorizer"] = config["vectorize_model"]
     try:
         llm_config_checker.check(json.dumps(llm_config))
         dim = vectorize_model_config_checker.check(json.dumps(vectorize_model_config))

--- a/knext/command/sub_command/project.py
+++ b/knext/command/sub_command/project.py
@@ -166,11 +166,18 @@ def create_project(
     llm_config_checker = LLMConfigChecker()
     vectorize_model_config_checker = VectorizeModelConfigChecker()
     llm_config = config.get("chat_llm", {})
-    vectorize_model_config = config.get("vectorizer", {})
+    vectorize_model_config = config.get("vectorizer", {}) or config.get(
+        "vectorize_model", {}
+    )
+    if "vectorizer" not in config and "vectorize_model" in config:
+        config["vectorizer"] = config.get("vectorize_model", {})
     try:
         llm_config_checker.check(json.dumps(llm_config))
         dim = vectorize_model_config_checker.check(json.dumps(vectorize_model_config))
-        config["vectorizer"]["vector_dimensions"] = dim
+        if "vectorizer" in config and isinstance(config["vectorizer"], dict):
+            config["vectorizer"]["vector_dimensions"] = dim
+        if "vectorize_model" in config and isinstance(config["vectorize_model"], dict):
+            config["vectorize_model"]["vector_dimensions"] = dim
     except Exception as e:
         click.secho(f"Error: {e}", fg="bright_red")
         sys.exit()


### PR DESCRIPTION
解决issue719问题。原因应该是向量化器配置在校验/导入时没有拿到 type （或拿到的是空配置），于是框架退回去尝试按基类构造，触发 pyhocon 的缺键异常，最终包装成 invalid vectorizer config: 'No configuration setting found for key name' 。我已经做出修改同时兼容 vectorizer 和 vectorize_model 两种写法，并把维度写回两边，避免后续流程再读空