### PR TITLE
Fix McpExecutor kag_project_config initialization for MCP HTTP store_…

### DIFF
--- a/kag/solver/executor/mcp/mcp_executor.py
+++ b/kag/solver/executor/mcp/mcp_executor.py
@@ -35,14 +35,15 @@ class McpExecutor(ExecutorABC):
         super().__init__(**kwargs)
         self.name = name
         self.description = description
+        # get project config
+        task_id = kwargs.get(KAGConstants.KAG_QA_TASK_CONFIG_KEY, None)
+        kag_config = KAGConfigAccessor.get_config(task_id)
+        self.kag_project_config = kag_config.global_config
         self.mcp_file_path = self.download_data(store_path)
         self.prompt = prompt
         self.env = dict(env)
         self.llm = llm
         self.mcp_client = MCPClient(self.llm, self.prompt)
-        task_id = kwargs.get(KAGConstants.KAG_QA_TASK_CONFIG_KEY, None)
-        kag_config = KAGConfigAccessor.get_config(task_id)
-        self.kag_project_config = kag_config.global_config
 
     def download_data(self, input: str, **kwargs):
         """


### PR DESCRIPTION
## Background

When configuring an external knowledge base with MCP support (e.g. Baidu Map MCP example), the solver uses `mcp_executor` to call an MCP tool via a Python script specified by `store_path`.

In this scenario, `store_path` can be an HTTP URL (e.g. a hosted `map.py` script). During runtime, the following error is raised when the MCP tool is invoked:

> `'McpExecutor' object has no attribute 'kag_project_config'`

## Root cause

In `kag/solver/executor/mcp/mcp_executor.py`, the initialization order in `McpExecutor.__init__` is:

```python
self.mcp_file_path = self.download_data(store_path)
...
task_id = kwargs.get(KAGConstants.KAG_QA_TASK_CONFIG_KEY, None)
kag_config = KAGConfigAccessor.get_config(task_id)
self.kag_project_config = kag_config.global_config
```

However, `download_data()` uses `self.kag_project_config` when `store_path` is an HTTP URL:

```python
local_file_path = os.path.join(
    self.kag_project_config.ckpt_dir, "mcp_service"
)
```

So when `store_path` starts with `http://` or `https://`, `download_data()` is called **before** `self.kag_project_config` is set, which leads to:

```text
AttributeError: 'McpExecutor' object has no attribute 'kag_project_config'
```

## Fix

Change the initialization order in `McpExecutor.__init__`:

1. First load the KAG project config via `KAGConfigAccessor.get_config(...)`.
2. Set `self.kag_project_config`.
3. Then call `self.download_data(store_path)` so that `download_data()` can safely use `self.kag_project_config.ckpt_dir`.

In pseudocode:

```python
task_id = kwargs.get(KAGConstants.KAG_QA_TASK_CONFIG_KEY, None)
kag_config = KAGConfigAccessor.get_config(task_id)
self.kag_project_config = kag_config.global_config

self.mcp_file_path = self.download_data(store_path)
```

This ensures that both local paths and HTTP URLs for `store_path` work correctly.

## Impact

- Fixes MCP scenarios where `mcp_executor.store_path` is an HTTP URL.
- No behavior change for:
  - Local `store_path` values.
  - Other executors and non-MCP pipelines.

## How I tested

1. Use the latest KAG docker image (2025-11-06).
2. Deploy on Ubuntu 22.04.
3. Build an external knowledge base using the `examples/baidu` example.
4. Apply for MCP credentials and configure `mcp_executor` with an HTTP `store_path` pointing to `map.py`.
5. Create an application and connect it to the external KB.
6. Ask a query such as “今天深圳的天气”.
7. Before this change: MCP call fails with `AttributeError: 'McpExecutor' object has no attribute 'kag_project_config'`.
8. After this change: MCP executor runs successfully and returns a normal answer.