### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
    <a href="https://discord.gg/PURG77zhQ7">
         <img src="https://img.shields.io/discord/1329648479709958236?style=for-the-badge&logo=discord&label=Discord" alt="Discord">
    </a>
+   <a href="https://gitcgr.com/openspg/kag">
+     <img src="https://gitcgr.com/badge/openspg/kag.svg" alt="gitcgr" />
+   </a>
 </p>
 
 # 1. What is KAG?


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/openspg/kag.svg)](https://gitcgr.com/openspg/kag)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).