### PR TITLE
fix: remove trailing comma that wrapped triples result in tuple in _invoke

### DIFF
--- a/kag/builder/component/extractor/schema_free_extractor.py
+++ b/kag/builder/component/extractor/schema_free_extractor.py
@@ -512,7 +512,7 @@ class SchemaFreeExtractor(ExtractorABC):
             {k: v for k, v in ent.items() if k in ["name", "category"]}
             for ent in entities
         ]
-        triples = (self.triples_extraction(passage, filtered_entities),)
+        triples = self.triples_extraction(passage, filtered_entities)
         std_entities = self.named_entity_standardization(passage, filtered_entities)
         self.append_official_name(entities, std_entities)
         self.assemble_sub_graph(sub_graph, input, entities, triples)


### PR DESCRIPTION
Fixes #743

## Problem

In the synchronous `_invoke` method of `SchemaFreeExtractor`, the result of `triples_extraction` was accidentally wrapped in a 1-element tuple due to a trailing comma:

```python
# Before (buggy)
triples = (self.triples_extraction(passage, filtered_entities),)
```

When `assemble_sub_graph_with_triples` iterates `for tri in triples:`, it received the **entire list** of triples as a single element rather than iterating individual triples. The check `if tri is None or len(tri) != 3:` then always skipped this element (since the list length is not 3), causing **all relationships to be silently dropped** in synchronous extraction mode.

The async `_ainvoke` path was unaffected because it uses `asyncio.gather`, which unpacks results correctly into `triples` directly.

## Solution

Remove the trailing comma so `triples` holds the list returned by `triples_extraction` directly:

```python
# After (fixed)
triples = self.triples_extraction(passage, filtered_entities)
```

## Testing

The fix aligns the synchronous `_invoke` behavior with the async `_ainvoke` path, which already worked correctly. The one-character change (removing the trailing comma) is the minimal fix needed.