### PR TITLE
fix: support both 'llm' and 'chat_llm' config keys; handle dict core_entities

### DIFF
--- a/kag/builder/component/extractor/knowledge_unit_extractor.py
+++ b/kag/builder/component/extractor/knowledge_unit_extractor.py
@@ -584,10 +584,15 @@ class KnowledgeUnitSchemaFreeExtractor(ExtractorABC):
                 {"name": knowledge_id, "category": "KnowledgeUnit"}
             )
             core_entities = {}
-            for item in knowledge_value.get("core_entities", "").split(","):
-                if not item.strip():
-                    continue
-                core_entities[item.strip()] = "Others"
+            raw_core_entities = knowledge_value.get("core_entities", {})
+            if isinstance(raw_core_entities, dict):
+                for key, val in raw_core_entities.items():
+                    if key.strip():
+                        core_entities[key.strip()] = val if val else "Others"
+            else:
+                for item in str(raw_core_entities).split(","):
+                    if item.strip():
+                        core_entities[item.strip()] = "Others"
 
             for core_entity, ent_type in core_entities.items():
                 if core_entity == "":

--- a/knext/command/sub_command/project.py
+++ b/knext/command/sub_command/project.py
@@ -165,7 +165,7 @@ def create_project(
 
     llm_config_checker = LLMConfigChecker()
     vectorize_model_config_checker = VectorizeModelConfigChecker()
-    llm_config = config.get("chat_llm", {})
+    llm_config = config.get("llm", config.get("chat_llm", {}))
     vectorize_model_config = config.get("vectorizer", {})
     try:
         llm_config_checker.check(json.dumps(llm_config))
@@ -260,7 +260,7 @@ def update_project(proj_path):
 
     llm_config_checker = LLMConfigChecker()
     vectorize_model_config_checker = VectorizeModelConfigChecker()
-    llm_config = env.config.get("chat_llm", {})
+    llm_config = env.config.get("llm", env.config.get("chat_llm", {}))
     vectorize_model_config = env.config.get("vectorizer", {})
     try:
         llm_config_checker.check(json.dumps(llm_config))


### PR DESCRIPTION
Fixes #731

## Problem

When creating a project using the 2wiki benchmark configs (e.g. `kag_config_knowledge_unit.yaml`), which define the LLM config under the `llm` top-level key, `project.py` was reading `chat_llm` — a different key used by other configs such as the medicine example. This caused the LLM config lookup to silently return an empty dict, leading to downstream errors (including `AttributeError: 'TaggedScalar' object has no attribute 'openapi_types'`).

Additionally, the English-language knowledge unit prompt returns `Core Entities` as a dict (`{"entity": "type", ...}`), but `knowledge_unit_extractor.py` was always treating `core_entities` as a comma-separated string, causing a `TypeError` when the English prompt was used.

## Solution

1. **`knext/command/sub_command/project.py`** — In both `create_project` and `update_project`, read the LLM config by checking `llm` first and falling back to `chat_llm`. This matches the existing logic in `kag/common/config.py::get_default_chat_llm_config()` and is backward-compatible with configs that use either key.

2. **`kag/builder/component/extractor/knowledge_unit_extractor.py`** — Handle `core_entities` as either a `dict` (English-language LLM output, where entity types are provided) or a comma-separated `str` (Chinese-language LLM output and triple-derived units). When it is a dict, the entity type value from the LLM is preserved instead of defaulting everything to `"Others"`.

## Testing

Verified the diff matches the fix described by the maintainer in the issue thread. The changes are backward-compatible: configs using `chat_llm` continue to work, and both Chinese and English prompt outputs for `core_entities` are correctly handled.